### PR TITLE
Rename render method to preactRender

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "preact-habitat",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { widgetDOMHostElements, _render } from "./lib";
+import { widgetDOMHostElements, preactRender } from "./lib";
 
 const habitat = Widget => {
   // Widget represents the Preact component we need to mount
@@ -26,7 +26,7 @@ const habitat = Widget => {
           inline,
           clientSpecified
         });
-        return _render(widget, elements, root, clean);
+        return preactRender(widget, elements, root, clean);
       }
     };
     loaded();

--- a/src/lib.js
+++ b/src/lib.js
@@ -51,7 +51,7 @@ const collectPropsFromElement = element => {
     }
   });
 
-  //check for child script text/props
+  // check for child script text/props
   [].forEach.call(element.getElementsByTagName('script'), scrp => {
     let propsObj = {}
     if(scrp.hasAttribute('type')) {
@@ -71,7 +71,7 @@ const collectPropsFromElement = element => {
 const getHabitatSelectorFromClient = (currentScript) => {
   let scriptTagAttrs = currentScript.attributes;
   let selector = null;
-  // ceck for another props attached to the tag
+  // check for another props attached to the tag
   Object.keys(scriptTagAttrs).forEach(key => {
     if (scriptTagAttrs.hasOwnProperty(key)) {
       const dataAttrName = scriptTagAttrs[key].name;
@@ -112,10 +112,10 @@ const widgetDOMHostElements = (
 };
 
 /**
- * private _render function that will be queued if the DOM is not render
+ * preact render function that will be queued if the DOM is not ready
  * and executed immeidatly if DOM is ready
  */
-let _render = (widget, hostElements, root, cleanRoot) => {
+const preactRender = (widget, hostElements, root, cleanRoot) => {
   hostElements.forEach(elm => {
     let hostNode = elm;
     if (hostNode._habitat) {
@@ -135,6 +135,6 @@ export {
   widgetDOMHostElements,
   getExecutedScript,
   camelcasize,
-  _render,
+  preactRender,
   getHabitatSelectorFromClient
 };


### PR DESCRIPTION
- `_render` wasn't really a private method. Renamed to `preactRender` to avoid confusion.
- Minor comment updates.