### PR TITLE
Inject props on render time with defaultProps option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ let habitat = habitat(WidgetAwesome);
 
 habitat.render({
   selector: '.some-class', // Searches and mounts in <div class="some-class"></div>
+  defaultProps: undefined, // Default props for all widgets
   inline: false,
   clean: false,
-  clientSpecified: false,
+  clientSpecified: false
 });
 ```
 
@@ -116,6 +117,12 @@ render function accepts an options Object which supports the following propertie
 >String: `.myclass`, `#myid`, `[data-selector="my-data-attr"]`
 
 DOM Element selector used to retrieve the DOM elements you want to mount the widget in
+
+#### option.defaultProps
+
+> Object: {} || undefined (default)
+
+Default props to be rendered throughout widgets, you can replace each value [declaring props](#passing-props).
 
 #### option.inline
 > Boolean: true || false (default)

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const habitat = Widget => {
       inline = false,
       clean = false,
       clientSpecified = false,
-      defaultProps
+      defaultProps = {}
     } = {}
   ) => {
     let elements = widgetDOMHostElements({

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,8 @@ const habitat = Widget => {
       selector = null,
       inline = false,
       clean = false,
-      clientSpecified = false
+      clientSpecified = false,
+      defaultProps
     } = {}
   ) => {
     let elements = widgetDOMHostElements({
@@ -26,7 +27,8 @@ const habitat = Widget => {
           inline,
           clientSpecified
         });
-        return preactRender(widget, elements, root, clean);
+
+        return preactRender(widget, elements, root, clean, defaultProps);
       }
     };
     loaded();

--- a/src/lib.js
+++ b/src/lib.js
@@ -115,7 +115,7 @@ const widgetDOMHostElements = (
  * preact render function that will be queued if the DOM is not ready
  * and executed immeidatly if DOM is ready
  */
-const preactRender = (widget, hostElements, root, cleanRoot, defaultProps = {}) => {
+const preactRender = (widget, hostElements, root, cleanRoot, defaultProps) => {
   hostElements.forEach(elm => {
     let hostNode = elm;
     if (hostNode._habitat) {

--- a/src/lib.js
+++ b/src/lib.js
@@ -32,9 +32,9 @@ const getExecutedScript = () => {
  * @param  {Element} tag The host element
  * @return {Object}  props object to be passed to the component
  */
-const collectPropsFromElement = element => {
+const collectPropsFromElement = (element, props = Object.create({})) => {
   let attrs = element.attributes;
-  let props = {};
+
   // collect from element
   Object.keys(attrs).forEach(key => {
     if (attrs.hasOwnProperty(key)) {
@@ -115,14 +115,14 @@ const widgetDOMHostElements = (
  * preact render function that will be queued if the DOM is not ready
  * and executed immeidatly if DOM is ready
  */
-const preactRender = (widget, hostElements, root, cleanRoot) => {
+const preactRender = (widget, hostElements, root, cleanRoot, defaultProps = Object.create({})) => {
   hostElements.forEach(elm => {
     let hostNode = elm;
     if (hostNode._habitat) {
       return; 
     }
     hostNode._habitat = true;
-    let props = collectPropsFromElement(elm) || {};
+    let props = collectPropsFromElement(elm, defaultProps) || defaultProps;
     if(cleanRoot) {
       hostNode.innerHTML = "";
     }

--- a/src/lib.js
+++ b/src/lib.js
@@ -32,7 +32,7 @@ const getExecutedScript = () => {
  * @param  {Element} tag The host element
  * @return {Object}  props object to be passed to the component
  */
-const collectPropsFromElement = (element, props = Object.create({})) => {
+const collectPropsFromElement = (element, props = {}) => {
   let attrs = element.attributes;
 
   // collect from element
@@ -115,7 +115,7 @@ const widgetDOMHostElements = (
  * preact render function that will be queued if the DOM is not ready
  * and executed immeidatly if DOM is ready
  */
-const preactRender = (widget, hostElements, root, cleanRoot, defaultProps = Object.create({})) => {
+const preactRender = (widget, hostElements, root, cleanRoot, defaultProps = {}) => {
   hostElements.forEach(elm => {
     let hostNode = elm;
     if (hostNode._habitat) {

--- a/src/test/lib.test.js
+++ b/src/test/lib.test.js
@@ -126,6 +126,59 @@ describe('Helper utility: collecting Client DOM props with collectPropsFromEleme
     expect(propsObj).toEqual(expectedProps);
   });
 
+  it('should collect props from prop script and merge with default props', () => {
+    document.body.innerHTML = `
+      <div id="parent" data-props-name="preact">
+        <script type="text/props">
+          {
+            "name": "zouhir"
+          }
+        </script>
+
+        <script type="text/javascript">
+
+        </script>
+      </div>
+    `
+    const habitatDiv = document.getElementById('parent');
+
+    const propsObj = collectPropsFromElement(habitatDiv, { project: "habitat" });
+
+    const expectedProps = {
+      "name": "zouhir",
+      "project": "habitat"
+    };
+    // document must find current script tag
+    expect(propsObj).toEqual(expectedProps);
+  });
+
+  it('should collect props from prop script replace default props', () => {
+    document.body.innerHTML = `
+      <div id="parent" data-props-name="preact">
+        <script type="text/props">
+          {
+            "name": "zouhir",
+            "project": "foobar"
+          }
+        </script>
+
+        <script type="text/javascript">
+
+        </script>
+      </div>
+    `
+    const habitatDiv = document.getElementById('parent');
+
+    const propsObj = collectPropsFromElement(habitatDiv, { project: "habitat" });
+
+    const expectedProps = {
+      "name": "zouhir",
+      "project": "foobar"
+    };
+    // document must find current script tag
+    expect(propsObj).toEqual(expectedProps);
+  });
+
 
   it('should collect props from prop multiple scripts', () => {
     document.body.innerHTML = `


### PR DESCRIPTION
Introduce `defaultProps` option in order to spread config throughout widgets on render time.

Quick example: Different widgets sharing the same WebSocket instance, but with specific payloads/messages though.

```js
habitat.render({
    selector: '.js-widgets',
    defaultProps: {
        ws: new WebSocket('ws://localhost:8080')
    }
});
```

Note: Test specs show how prop inheritance works in case of [inline config](https://github.com/zouhir/preact-habitat#passing-props).