### PR TITLE
Add TypeScript declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main:umd": "dist/preact-habitat.umd.js",
   "jsnext:main": "dist/preact-habitat.es.js",
   "homepage": "https://github.com/zouhir/preact-habitat/",
+  "types": "src/habitat.d.ts",
   "author": {
     "name": "Zouhir Chahoud",
     "email": "zouhir@zouhir.org",

--- a/src/habitat.d.ts
+++ b/src/habitat.d.ts
@@ -31,7 +31,16 @@ declare module "preact-habitat" {
     clientSpecified?: boolean;
   }
   interface IHabitat {
+    /**
+     * Renders the preact component into the DOM.
+     * @param config Configuration object
+     */
     render(config: IHabitatRenderConfig): void;
   }
+  /**
+   * A 900 Bytes module for that will make plugging in Preact components and
+   * widgets in any CMS or website as fun as lego!
+   * @param widget {ComponentFactory} Component to plug
+   */
   export default function habitat<P>(widget: ComponentFactory<P>): IHabitat;
 }

--- a/src/habitat.d.ts
+++ b/src/habitat.d.ts
@@ -1,10 +1,33 @@
 declare module "preact-habitat" {
   import { ComponentFactory } from "preact";
   interface IHabitatRenderConfig {
+    /**
+     * DOM Element selector used to retrieve the DOM elements you want to mount
+     * the widget in.
+     */
     selector: string;
+    /**
+     * Default props to be rendered throughout widgets, you can replace each
+     * value declaring props.
+     * @default {}
+     */
     defaultProps?: any;
+    /**
+     * Set to true if you want to use the parent DOM node as a host for your
+     * widget without specifing any selectors.
+     * @default true
+     */
     inline?: boolean;
+    /**
+     * clean will remove all the innerHTML from the HTMl element the widget will
+     * mount in.
+     * @default false
+     */
     clean?: boolean;
+    /**
+     * Whether the client will specify the selector. Overwrites selector option.
+     * @default false
+     */
     clientSpecified?: boolean;
   }
   interface IHabitat {

--- a/src/habitat.d.ts
+++ b/src/habitat.d.ts
@@ -1,0 +1,14 @@
+declare module "preact-habitat" {
+  import { ComponentFactory } from "preact";
+  interface IHabitatRenderConfig {
+    selector: string;
+    defaultProps?: any;
+    inline?: boolean;
+    clean?: boolean;
+    clientSpecified?: boolean;
+  }
+  interface IHabitat {
+    render(config: IHabitatRenderConfig): void;
+  }
+  export default function habitat<P>(widget: ComponentFactory<P>): IHabitat;
+}


### PR DESCRIPTION
Typescript users currently have to manually write or copy the declaration file into their project in order for Typescript to take the module into account. By bundling the definition with the module itself the module becomes TS-ready!