### PR TITLE
Update habitat.d.ts to give optional selector

### DIFF
--- a/src/habitat.d.ts
+++ b/src/habitat.d.ts
@@ -5,7 +5,7 @@ declare module "preact-habitat" {
      * DOM Element selector used to retrieve the DOM elements you want to mount
      * the widget in.
      */
-    selector: string;
+    selector?: string;
     /**
      * Default props to be rendered throughout widgets, you can replace each
      * value declaring props.


### PR DESCRIPTION
This looks like it should be optional since the code in index.js sets it to null by default