### PR TITLE
Ignore hosts that no longer exits

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -124,6 +124,9 @@ const widgetDOMHostElements = (
 const preactRender = (widget, hostElements, root, cleanRoot, defaultProps) => {
   hostElements.forEach(elm => {
     let hostNode = elm;
+    if (!hostNode) {
+      return;
+    }
     if (hostNode._habitat) {
       return; 
     }


### PR DESCRIPTION
I have some weird cases with CMS that loads content dynamically and still providing HTML from the server-side.

In this case, code is executed twice but the second execution will fail because the node element is no longer present in the dom.